### PR TITLE
Fix some imageArticles seed bug

### DIFF
--- a/server/seeders/2024.02.29T09.16.31.imageArticles.mjs
+++ b/server/seeders/2024.02.29T09.16.31.imageArticles.mjs
@@ -5,6 +5,7 @@ import S3Service from '../services/S3Client.js';
 import { handleAsyncError } from '../utils/handleErrors.js';
 import { readFileAsync } from '../utils/fsUtils.js';
 import { Buffer } from 'buffer';
+import Image from '../models/Image.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -58,17 +59,17 @@ export const up = handleAsyncError(async ({ context: { sequelize } }) => {
       // Insert new image raw in images table
       return {
         imageableId: article.id,
-        imageableType: 'ARTICLE',
-        name: name,
+        imageableType: Image.ARTICLE,
+        name,
       };
     });
 
     await queryInterface.bulkInsert('Images', newImages, {
-      where: { imageableType: 'ARTICLE' },
+      where: { imageableType: Image.ARTICLE },
     });
 
     const createdImages = await queryInterface.select(null, 'Images', {
-      where: { imageableType: 'ARTICLE' },
+      where: { imageableType: Image.ARTICLE },
     });
 
     await Promise.all(
@@ -81,12 +82,13 @@ export const up = handleAsyncError(async ({ context: { sequelize } }) => {
     );
   });
 });
+
 export const down = handleAsyncError(async ({ context: { sequelize } }) => {
   const queryInterface = sequelize.getQueryInterface();
   await sequelize.transaction(async (transaction) => {
     // Fetch all Article images
     const articleImages = await queryInterface.select(null, 'Images', {
-      where: { imageableType: 'ARTICLE' },
+      where: { imageableType: Image.ARTICLE },
       attributes: ['name'],
     });
 
@@ -99,7 +101,7 @@ export const down = handleAsyncError(async ({ context: { sequelize } }) => {
     );
     // Bulk Delete article images from database
     await queryInterface.bulkDelete('Images', {
-      imageableType: 'ARTICLE',
+      imageableType: Image.ARTICLE,
     });
   });
 });

--- a/server/services/ArticleService.js
+++ b/server/services/ArticleService.js
@@ -40,7 +40,7 @@ export default class ArticleService {
 
     // Create a data object containing the necessary data to update a metric
     const data = { uuid, ipAddress, articleId };
-    const metricUUID = Metrics.updateMetric(model, data);
+    const metricUUID = await Metrics.updateMetric(model, data);
     return {
       metricUUID,
       cookie,

--- a/server/services/Metrics.js
+++ b/server/services/Metrics.js
@@ -14,12 +14,12 @@ export default class Metrics {
    *
    * @param {object} model - The Sequelize model for the metric (e.g., View or Share).
    * @param {object} data - The data for the metric, including uuid, ipAddress, and articleId.
-   * @returns {string} The unique UUID of the metric, either newly created or existing.
+   * @returns {Promise<string>} A promise that resolves to the unique UUID of the metric,
+   * either newly created or existing.
    * @throws {Error} If the ipAddress or articleId is not provided.
    */
   static async updateMetric(model, data) {
     const { uuid, ipAddress, articleId } = data;
-
     // Validate input parameters
     if (!ipAddress) {
       throw new Error('IpAddress is required');
@@ -32,7 +32,7 @@ export default class Metrics {
     const twentyFourHoursAgo = new Date(new Date() - 24 * 60 * 60 * 1000);
 
     // Perform database operations within a transaction for data integrity
-    return await db.sequelize.transaction(async (t) => {
+    return db.sequelize.transaction(async (t) => {
       // Check if the metric for this article and user (IP or UUID) already exists in the last 24 hours
       const existingMetric = await model.findOne({
         where: {

--- a/server/umzug/migrate.js
+++ b/server/umzug/migrate.js
@@ -1,8 +1,3 @@
 import { migrator } from './umzug.js';
 
-try {
-  migrator.runAsCLI();
-  console.log('Migration completed successfully');
-} catch (error) {
-  console.error('Migration failed:', error);
-}
+migrator.runAsCLI();

--- a/server/umzug/seed.js
+++ b/server/umzug/seed.js
@@ -1,8 +1,3 @@
 import { seeder } from './umzug.js';
 
-try {
-  seeder.runAsCLI();
-  console.log('Seeding completed successfully');
-} catch (error) {
-  console.error('Seeding failed:', error);
-}
+seeder.runAsCLI();

--- a/server/utils/handleErrors.js
+++ b/server/utils/handleErrors.js
@@ -1,9 +1,10 @@
 const handleAsyncError = (func) => {
   return async (...args) => {
     try {
-      await func(...args);
+      return await func(...args);
     } catch (error) {
       console.error('Caught an error in handleAsyncError:', error);
+      throw error;
     }
   };
 };
@@ -11,7 +12,7 @@ const handleAsyncError = (func) => {
 const handleAsyncApiError = (func) => {
   return async (req, res, next) => {
     try {
-      await func(req, res, next); // Await here to fully capture async behavior
+      return await func(req, res, next);
     } catch (error) {
       console.error('Caught an error in handleAsyncApiError:', error);
       next(error);


### PR DESCRIPTION
Fix handleAsyncError (Added missed returned statement)
Changed the "Metric.updateMetric" to return a promise and await for it when calling it
Use the correct imageableType in imageArticles.mjs seeder
Change migrate.js and seed.js to use the "runAsCLI"  back (otherwise it would break the scripts added to package.json file)