### PR TITLE
update password regex to allow any symbol

### DIFF
--- a/server/middleware/requests/users/signupRequest.js
+++ b/server/middleware/requests/users/signupRequest.js
@@ -8,7 +8,7 @@ const signupRequest = Joi.object({
     .max(64)
     .pattern(
       new RegExp(
-        '^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{12,64}$',
+        '^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d])[A-Za-z\\d\\S]{12,64}$',
       ),
     )
     .required()


### PR DESCRIPTION
- Modified regex pattern to accept any non-alphanumeric character as a symbol
- Ensures broader compatibility for password requirements by removing specific symbol limitations